### PR TITLE
django.confg.urls.defaults is deprecated in Django 1.4, removed in Django 1.6

### DIFF
--- a/ratings/urls.py
+++ b/ratings/urls.py
@@ -1,5 +1,9 @@
-from django.conf.urls.defaults import *
-
+try:
+    # Django > 1.6
+    from django.conf.urls import patterns, url
+except ImportError:
+    # Django < 1.6
+    from django.conf.urls.defaults import patterns, url
 
 urlpatterns = patterns('ratings.views',
     url(r'^rate/(?P<ct>\d+)/(?P<pk>[^\/]+)/(?P<score>\-?[\d\.]+)/$', 'rate_object', name='ratings_rate_object'),


### PR DESCRIPTION
Since django.confg.urls.defaults is deprecated in Django 1.4, removed in Django 1.6 a conditional import is need to be compatible with Django 1.6
