### PR TITLE
Fix Django 1.7 compatibility issue. Closes #6.

### DIFF
--- a/ratings/ratings_tests/tests.py
+++ b/ratings/ratings_tests/tests.py
@@ -517,6 +517,7 @@ class RatingsTestCase(TestCase):
         ))
         resp = self.client.post(test_url, {}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp['Content-Type'], 'application/json')
 
         self.assertEqual(self.item1.ratings.cumulative_score(), 2.5)
 

--- a/ratings/views.py
+++ b/ratings/views.py
@@ -35,7 +35,8 @@ def rate_object(request, ct, pk, score=1, add=True):
         ratings_descriptor.unrate(request.user)
 
     if request.is_ajax():
-        return HttpResponse('{"success": true}', mimetype='application/json')
+        return HttpResponse('{"success": true}',
+                            content_type='application/json')
     try:
         return HttpResponseRedirect(request.REQUEST.get('next') or
                                     request.META.get('HTTP_REFERER'))


### PR DESCRIPTION
The HttpResponse parameter `mimetype` has been removed with Django 1.7
favor of the `content_type` parameter.

https://docs.djangoproject.com/en/1.7/releases/1.7/#features-removed-in-1-7